### PR TITLE
Fix cuda-nvcc tests

### DIFF
--- a/recipes/cuda-nvcc/meta.yaml
+++ b/recipes/cuda-nvcc/meta.yaml
@@ -29,6 +29,13 @@ build:
   number: 0
   skip: true  # [osx]
 
+test:
+  files:
+    - test.cu
+  commands:
+    - nvcc --version
+    - nvcc --verbose test.cu
+
 outputs:
   - name: cuda-nvcc
     build:
@@ -60,12 +67,7 @@ outputs:
       run_constrained:
         - gcc_impl_{{ target_platform }} >=6,<13  # [linux]
         - arm-variant * {{ arm_variant_type }}    # [aarch64]
-    test:
-      files:
-        - test.cu
-      commands:
-        - nvcc --version
-        - nvcc --verbose test.cu
+    # Tests are defined at the top level, due to package/output name conflicts.
     about:
       home: https://developer.nvidia.com/cuda-toolkit
       license_file: LICENSE


### PR DESCRIPTION
Fixes cuda-nvcc tests. See https://github.com/conda-forge/libcublas-feedstock/pull/10 for context.